### PR TITLE
Add tzdata package to prod image

### DIFF
--- a/resources/ut.sh
+++ b/resources/ut.sh
@@ -91,6 +91,7 @@ if [ "${GIT_BRANCH}" = "origin/master" ]; then
 EOF
     docker build -t ${JOB_NAME} . -f-<<EOF
         FROM $IMAGE
+        RUN apk add --no-cache tzdata
         COPY --from=${JOB_NAME}:prod /app /app
         WORKDIR /app
         COPY dist dist


### PR DESCRIPTION
When **tzdata** package is installed, then we can control timezone using env var TZ, e.g.


```
asdf➤ date
Fri 02 Aug 2019 04:51:51 PM EEST
asdf➤ docker run --rm -it -e TZ="Europe/Sofia" mhart/alpine-node:base-10.15.3 date
Fri Aug  2 13:52:03 UTC 2019
asdf➤ cat Dockerfile                                           
from mhart/alpine-node:base-10.15.3
RUN apk add -U tzdata
asdf➤ docker build -t mhar_tzdata . 1>/dev/null                
asdf➤ docker run --rm -it -e TZ="Europe/Sofia" mhar_tzdata date                   
Fri Aug  2 16:52:23 EEST 2019
asdf➤ 
```
