### PR TITLE
fix: EACCES: permission denied, open '/app/lint.xml'

### DIFF
--- a/resources/ut.sh
+++ b/resources/ut.sh
@@ -57,6 +57,8 @@ RUN set -xe\
  && git --version && bash --version && ssh -V && npm -v && node -v && yarn -v\
  && mkdir /var/lib/SoftwareGroup && chown -R node:node /var/lib/SoftwareGroup
 WORKDIR /app
+RUN chown -R node:node /app
+USER node
 END
 )
 fi


### PR DESCRIPTION
We need to change the default permission of /app folder when using the official node image

For more info: https://jenkins.softwaregroup.com/job/ut/job/ut-testtools/job/master/8/console