### PR TITLE
Replace the obsolete 'checkstyle' plugin with the 'Warnings Next Generation' plugin

### DIFF
--- a/vars/ut.groovy
+++ b/vars/ut.groovy
@@ -46,7 +46,7 @@ def call(Map params = [:]) {
                                 scanner = readProperties file: files[0].path, defaults: [dashboardUrl:'https://sonar.softwaregroup.com']
                             }
                         }
-                        checkstyle pattern: '.lint/lint*.xml', canRunOnFailed: true
+                        recordIssues enabledForFailure: true, ignoreFailedBuilds: false, tools: [checkStyle(pattern: '.lint/lint*.xml')]
                         step([$class: "TapPublisher", testResults: ".lint/tap.txt", verbose: false, enableSubtests: true, planRequired: false])
                         cobertura coberturaReportFile: 'coverage/cobertura-coverage.xml', failNoReports: false
                         perfReport sourceDataFiles: '.lint/load/*.csv', failBuildIfNoResultFile: false, compareBuildPrevious: true


### PR DESCRIPTION
The 'checkstyle' plugin is no longer supported. We'll use the 'Warnings Next Generation' plugin instead. 

For more info: https://issues.jenkins.io/browse/INFRA-2487.

Example: https://jenkins.softwaregroup.com/job/ut5impl/job/impl-devops-test/job/feature%252FBR-879/4/checkstyle/
