### PR TITLE
Remove unused method 'updateGitlabCommitStatus'

### DIFF
--- a/vars/ut.groovy
+++ b/vars/ut.groovy
@@ -116,23 +116,6 @@ ${FILE,path=".lint/test.txt"}
                             subject: 'Build ${BUILD_STATUS} in Jenkins: ' + repoUrl.replaceAll(/^[^\/]*\/|.git$/, "") + ' ${BUILD_DISPLAY_NAME} (' + currentBuild.durationString +')'
                         )
                     }
-                    failure {
-                        script {
-                            if (repoUrl.substring(0,14) == 'git@github.com') {
-                            } else {
-                                updateGitlabCommitStatus name: 'build', state: 'failed'
-                            }
-                        }
-                        // https://doc.nuxeo.com/corg/jenkins-pipeline-usage/
-                    }
-                    success {
-                        script {
-                            if (repoUrl.substring(0,14) == 'git@github.com') {
-                            } else {
-                                updateGitlabCommitStatus name: 'build', state: 'success'
-                            }
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
![jenkinsfile](https://user-images.githubusercontent.com/17120716/140293289-147e52d5-e107-4d91-a6f0-5b52d1b4a115.png)

We use two functionalities to return status to GitLab:
- 'updateGitlabCommitStatus' - part of the GitLab plugin (not configured)
- 'GitLab Pipeline Status' - part of the GitLab Source Plugin

So, based on our tests,  we can safely remove the 'updateGitlabCommitStatus' method.

For more info:
- https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/master/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java (lines 258-... )
- https://www.jenkins.io/blog/2019/08/23/introducing-gitlab-branch-source-plugin/ - GitLab Pipeline Status Notification section
- https://plugins.jenkins.io/gitlab-plugin/#notify-specific-project-by-a-specific-gitlab-connection


Passed Tests:
- https://github.com/softwaregroup-bg/ut-testtools/commits/master
- https://git.softwaregroup.com/ut5impl/impl-devops-test/blob/devops/README.md