### PR TITLE
feat: print node and npm versions

### DIFF
--- a/resources/ut.sh
+++ b/resources/ut.sh
@@ -94,7 +94,7 @@ RUN mkdir -p /app/node_modules/.cache \
   && npm config delete cache
 COPY --chown=node:node . .
 EOF
-docker run -u node:node -i --rm -v "$(pwd)/.lint:/app/.lint" ${UT_PROJECT}:${TEST_IMAGE_TAG} /bin/sh -c "npm ls -a > .lint/npm-ls.txt" || true
+docker run -u node:node -i --rm -v "$(pwd)/.lint:/app/.lint" ${UT_PROJECT}:${TEST_IMAGE_TAG} /bin/sh -c " { node -v; npm -v; npm ls -a; } > .lint/npm-ls.txt" || true
 docker run -u node:node -i \
     -v ~/.ssh:/home/node/.ssh:ro \
     -v ~/.npmrc:/home/node/.npmrc:ro \


### PR DESCRIPTION
Save node -v and npm -v to npm-ls.txt file.

![image](https://github.com/softwaregroup-bg/jenkinsfile/assets/17120716/4c34b7a9-ee3a-4646-a2ea-53168bc76f16)

and

https://jenkins.softwaregroup.com/job/ut5impl/job/impl-application/job/BR-1127/5/execution/node/4/ws/.lint/npm-ls.txt/*view*/
