### PR TITLE
[BR-1174] Login to nexus dev docker repository before pulling base image

### DIFF
--- a/resources/ut.sh
+++ b/resources/ut.sh
@@ -20,12 +20,14 @@ if [[ ${UT_PROJECT} =~ impl-(.*) ]]; then
     UT_IMPL=${BASH_REMATCH[1]}
     UT_MODULE=${UT_IMPL}
     UT_PREFIX=ut_${UT_IMPL//[-\/\\]/_}_jenkins
+    echo "$DOCKER_PSW" | docker login -u "$DOCKER_USR" --password-stdin nexus-dev.softwaregroup.com:5001
     docker pull nexus-dev.softwaregroup.com:5000/softwaregroup/impl-gallium
 fi
 if [[ ${UT_PROJECT} =~ ut-(.*) ]]; then
     # SONAR_PREFIX=ut5impl/
     UT_MODULE=${BASH_REMATCH[1]}
     UT_PREFIX=ut_${BASH_REMATCH[1]//[-\/\\]/_}_jenkins
+    echo "$DOCKER_PSW" | docker login -u "$DOCKER_USR" --password-stdin nexus-dev.softwaregroup.com:5001
     docker pull nexus-dev.softwaregroup.com:5000/softwaregroup/node-gallium
     docker pull nexus-dev.softwaregroup.com:5000/softwaregroup/ut-gallium
 fi

--- a/resources/ut.sh
+++ b/resources/ut.sh
@@ -15,19 +15,18 @@ DBSUFFIX=
 if [[ ${CHANGE_ID} ]]; then
     DBSUFFIX=-${CHANGE_ID}
 fi
+echo "$DOCKER_PSW" | docker login -u "$DOCKER_USR" --password-stdin nexus-dev.softwaregroup.com:5000
 if [[ ${UT_PROJECT} =~ impl-(.*) ]]; then
     # SONAR_PREFIX=ut5/
     UT_IMPL=${BASH_REMATCH[1]}
     UT_MODULE=${UT_IMPL}
     UT_PREFIX=ut_${UT_IMPL//[-\/\\]/_}_jenkins
-    echo "$DOCKER_PSW" | docker login -u "$DOCKER_USR" --password-stdin nexus-dev.softwaregroup.com:5001
     docker pull nexus-dev.softwaregroup.com:5000/softwaregroup/impl-gallium
 fi
 if [[ ${UT_PROJECT} =~ ut-(.*) ]]; then
     # SONAR_PREFIX=ut5impl/
     UT_MODULE=${BASH_REMATCH[1]}
     UT_PREFIX=ut_${BASH_REMATCH[1]//[-\/\\]/_}_jenkins
-    echo "$DOCKER_PSW" | docker login -u "$DOCKER_USR" --password-stdin nexus-dev.softwaregroup.com:5001
     docker pull nexus-dev.softwaregroup.com:5000/softwaregroup/node-gallium
     docker pull nexus-dev.softwaregroup.com:5000/softwaregroup/ut-gallium
 fi


### PR DESCRIPTION
On 2024-02-21 at 11:59 we changed the nexus-dev admin password to a more secure one, unaware that jenkins uses the admin account to pull/push images relating to the ut projects. When a build failed & was reported under this ticket, I updated the credentials in Jenkins but the build was still failing. To unblock developers, I manually updated the stored docker credentials on the build nodes.
Docker credentials are reused from previous builds and we only login before tagging and pushing an image, thus simply updating the credentials stored in Jenkins under `dockerPublisher` is not enough when rotating passwords.